### PR TITLE
PB-27: Add Tags to Transaction Descriptions

### DIFF
--- a/src/components/FileUpload/FileUploadParser.js
+++ b/src/components/FileUpload/FileUploadParser.js
@@ -1,6 +1,6 @@
 import FileInput from "./FileInput";
 import { Button } from "react-bootstrap";
-import { parseCSV, rowToTransaction } from "../../events/ParsingEvents";
+import { normalizeTransactions, parseCSV, rowToTransaction } from "../../events/ParsingEvents";
 import { useState, useContext } from "react";
 import { v4 as uuidv4 } from 'uuid';
 import { DataContext, ACTION_SET_TRANSACTIONS } from "../../contexts/DataContext";
@@ -11,21 +11,21 @@ const FileUploadParser = () => {
     const [file, setFile] = useState('');
 
     const handleOnParseClick = () => {
-        console.log("HANDLE CLICK " + parseCSV(file.target.files[0], rowToTransaction));
-        console.log("Method: " + parseCSV);
+
         parseCSV(file.target.files[0], rowToTransaction).then(result => {
-            console.log("Thening");
+
+            const transactionDescriptions = normalizeTransactions(result);
 
             const fileDetails = {
-              id: uuidv4(),
-              data: result
+                transactions: result,
+                transactionDescriptions: transactionDescriptions,
             }
-        
+
             dispatch({
-              type: ACTION_SET_TRANSACTIONS,
-              payload: fileDetails,
+                type: ACTION_SET_TRANSACTIONS,
+                payload: fileDetails,
             });
-        
+
         });
     }
 

--- a/src/components/SideBar/Main.js
+++ b/src/components/SideBar/Main.js
@@ -4,6 +4,7 @@ import { Button, Collapse, Card } from "react-bootstrap";
 import { SideBarProvider } from "../../contexts/SideBarContext";
 import { Tab, Tabs } from "react-bootstrap";
 import TagView from "./TagView";
+import TransactionDescriptionView from "./TransactionDescriptionView";
 
 
 
@@ -27,6 +28,9 @@ const SideBar = () => {
                         <Tabs defaultActiveKey="transactions" class="sidebar-collapse">
                             <Tab eventKey="transactions" title="Transactions">
                                 <TransactionView />
+                            </Tab>
+                            <Tab eventKey="descriptions" title="Descriptions">
+                                <TransactionDescriptionView />
                             </Tab>
                             <Tab eventKey="tags" title="Tags">
                                 <TagView />

--- a/src/components/SideBar/TagView.js
+++ b/src/components/SideBar/TagView.js
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { FormControl, Table, Button } from 'react-bootstrap';
-import { DataContext } from '../../contexts/DataContext';
+import { DataContext, DEFAULT_TAG_ID } from '../../contexts/DataContext';
 
 
 const TagRow = ({ tag }) => {
@@ -25,6 +25,10 @@ const TagRow = ({ tag }) => {
 
     const handleDeleteTagButtonClick = (event) => {
         const tagId = event.target.getAttribute('tagid');
+
+        if (tagId == DEFAULT_TAG_ID) {
+            return;
+        }
         dispatch({
             type: 'DELETE_TAG',
             payload: {
@@ -37,7 +41,7 @@ const TagRow = ({ tag }) => {
         <tr>
             <td><FormControl type="text" defaultValue={tag.name} dispatchtype="SET_TAG_NAME" tagid={tag.id} onChange={handleOnDataChange} /></td>
             <td><FormControl type="color" defaultValue={tag.colour} dispatchtype="SET_TAG_COLOUR" tagid={tag.id} onChange={handleOnDataChange} /></td>
-            <td><Button variant="danger" className="circular-button" tagid={tag.id} onClick={handleDeleteTagButtonClick}>-</Button></td>
+            <td>{tag.id != DEFAULT_TAG_ID && <Button variant="danger" className="circular-button" tagid={tag.id} onClick={handleDeleteTagButtonClick}>-</Button>}</td>
         </tr>
     );
 }

--- a/src/components/SideBar/TransactionDescriptionView.js
+++ b/src/components/SideBar/TransactionDescriptionView.js
@@ -1,0 +1,81 @@
+import { Table, Dropdown } from 'react-bootstrap';
+import { useContext } from 'react';
+import { ACTION_SET_TRANSACTION_DESCRIPTION_TAG, DataContext, DEFAULT_TAG_ID } from '../../contexts/DataContext';
+
+
+const TransactionDescriptionRow = ({ transactionDescription }) => {
+
+    const { state, dispatch } = useContext(DataContext);
+
+    if (transactionDescription.tag == null) {
+        const defaultTag = state.tags.find((tag) => tag.id == DEFAULT_TAG_ID);
+        transactionDescription.tag = defaultTag;
+    }
+
+    const handleSelection = (tag) => {
+        
+        dispatch({
+            type: ACTION_SET_TRANSACTION_DESCRIPTION_TAG,
+            payload: {
+                transactionDescription: transactionDescription,
+                tag: tag,
+            }
+        });
+    }
+
+    return (
+        <tr>
+            <td>{transactionDescription.name}</td>
+            <td>{transactionDescription.tag.name}</td>
+            <td>
+                <Dropdown>
+                    <Dropdown.Toggle variant="info">
+                        Change Tag
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                        {state.tags.map((tag) => {
+                            return <Dropdown.Item onClick={() => handleSelection(tag)}>{tag.name}</Dropdown.Item>
+                        })}
+                    </Dropdown.Menu>
+                </Dropdown>
+            </td>
+        </tr>
+    );
+}
+
+
+const TransactionDescriptionTable = () => {
+
+    const { state } = useContext(DataContext);
+    const transactionDescriptions = state.descriptions;
+
+
+    return (
+        <Table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Tag</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {transactionDescriptions.map((transactionDescription) => {
+                    return <TransactionDescriptionRow transactionDescription={transactionDescription} />
+                })}
+            </tbody>
+        </Table>
+    );
+}
+
+
+const TransactionDescriptionView = () => {
+    return (
+        <div>
+            <h1>Transaction Descriptions</h1>
+            <TransactionDescriptionTable />
+        </div>
+    )
+}
+
+export default TransactionDescriptionView;

--- a/src/components/SideBar/TransactionView.js
+++ b/src/components/SideBar/TransactionView.js
@@ -7,10 +7,11 @@ import { FormatMoney, FormatDate } from "../../utils/Utils";
 
 
 const TransactionRow = ({ transaction }) => {
+    
     return (
         <tr>
             <td>{FormatDate(transaction.date)}</td>
-            <td>{transaction.description}</td>
+            <td>{transaction.description.name}</td>
             <td>{FormatMoney(transaction.amount)}</td>
             <td>{transaction.transactionType}</td>
         </tr>

--- a/src/contexts/DataContext.js
+++ b/src/contexts/DataContext.js
@@ -8,6 +8,9 @@ export const ACTION_SET_TAG_NAME = 'SET_TAG_NAME';
 export const ACTION_SET_TAG_COLOUR = 'SET_TAG_COLOUR';
 export const ACTION_DELETE_TAG = 'DELETE_TAG';
 export const ACTION_ADD_TAG = 'ADD_TAG';
+export const ACTION_SET_TRANSACTION_DESCRIPTION_TAG = 'SET_TRANSACTION_DESCRIPTION_TAG';
+
+export const DEFAULT_TAG_ID = 1;
 
 const DataReducer = (state, action) => {
 
@@ -15,7 +18,8 @@ const DataReducer = (state, action) => {
         case ACTION_SET_TRANSACTIONS:
             return {
                 ...state,
-                transactions: action.payload.data
+                transactions: action.payload.transactions,
+                descriptions: action.payload.transactionDescriptions
             }
 
         case ACTION_SET_TAG_NAME:
@@ -56,6 +60,17 @@ const DataReducer = (state, action) => {
                 ...state,
                 tags: state.tags
             }
+
+        case ACTION_SET_TRANSACTION_DESCRIPTION_TAG:
+            const transactionDescription = action.payload.transactionDescription;
+            const tag = action.payload.tag;
+            transactionDescription.tag = tag;
+            
+            return {
+                ...state,
+                descriptions: state.descriptions
+            }
+
             
         default:
             return state;
@@ -66,7 +81,8 @@ const DataContext = React.createContext();
 
 const initialState = {
     transactions: [],
-    tags: [new Tag(1, 'Food', '#ff0000'), new Tag(2, 'Transport', '#00ff00'), new Tag(3, 'Entertainment', '#0000ff')]
+    descriptions: [],
+    tags: [new Tag(DEFAULT_TAG_ID, 'Default', '#ffffff')]
 }
 
 const DataProvider = ({ children }) => {

--- a/src/events/ParsingEvents.js
+++ b/src/events/ParsingEvents.js
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { ExcelRenderer } from 'react-excel-renderer';
 import Transaction from '../models/Transaction';
+import TransactionDescription from '../models/TransactionDescription';
 
 
 const defaultTransactionFieldToColumn = {
@@ -39,6 +40,23 @@ const parseCSV = (file, rowToObject) => {
 }
 
 
+const normalizeTransactions = (transactions) => {
+
+    const transactionDescriptions = {};
+
+    transactions.forEach(transaction => {
+        if (!transactionDescriptions[transaction.description]) {
+            transactionDescriptions[transaction.description] = new TransactionDescription(uuidv4(), transaction.description);
+        }
+        transaction.description = transactionDescriptions[transaction.description];
+    });
+
+    return Object.values(transactionDescriptions);
+
+}
+    
+
+
 const rowToTransaction = (row, transactionFieldToColumn = defaultTransactionFieldToColumn) => {
 
     let dateCol = transactionFieldToColumn['date'];
@@ -56,4 +74,4 @@ const rowToTransaction = (row, transactionFieldToColumn = defaultTransactionFiel
 }
 
 
-export { parseCSV, rowToTransaction };
+export { parseCSV, rowToTransaction, normalizeTransactions };

--- a/src/models/TransactionDescription.js
+++ b/src/models/TransactionDescription.js
@@ -1,0 +1,8 @@
+class TransactionDescription {
+    constructor(id, description){
+        this.id = id;
+        this.name = description;
+    }
+}
+
+export default TransactionDescription;

--- a/src/tests/events/ParsingEvents.test.js
+++ b/src/tests/events/ParsingEvents.test.js
@@ -10,7 +10,6 @@ describe('parseCSV', () => {
     const testFileContents = async (contents, expectedResult) => {
         const blob = new Blob([contents]);
         const file = new File([blob], 'mockedFileName.csv', { type: 'text/csv' });
-        console.log(blob);
 
         await expect(parseCSV(file, rowToObject)).resolves.toStrictEqual(expectedResult);
     }
@@ -23,7 +22,6 @@ describe('parseCSV', () => {
 
     testCases.forEach((testCase) => {
         it(testCase.name, async () => {
-            console.log(testCase.name);
             await testFileContents(testCase.contents, testCase.expectedResult);
         });
     });


### PR DESCRIPTION
    Allow for transactions to be tagged en masse by separating transaction
    descriptions into a separate model that has a relation with tags.

    Create a new tab in the SideBar to allow for users to view and edit
    transaction descriptions.