### PR TITLE
PB-35: Configure ParseCSV Column Mapping

### DIFF
--- a/src/components/FileUpload/FileUploadParser.js
+++ b/src/components/FileUpload/FileUploadParser.js
@@ -10,9 +10,22 @@ const FileUploadParser = () => {
     const { dispatch } = useContext(DataContext);
     const [file, setFile] = useState('');
 
+
+    const [dateCol, setDateCol] = useState(0);
+    const [descriptionCol, setDescriptionCol] = useState(1);
+    const [expenseCol, setExpenseCol] = useState(2);
+    const [depositCol, setDepositCol] = useState(3);
+
     const handleOnParseClick = () => {
 
-        parseCSV(file.target.files[0], rowToTransaction).then(result => {
+        const transactionFieldToColumn = {
+            'date': dateCol,
+            'description': descriptionCol,
+            'expense': expenseCol,
+            'deposit': depositCol
+        }
+
+        parseCSV(file.target.files[0], rowToTransaction, transactionFieldToColumn).then(result => {
 
             const transactionDescriptions = normalizeTransactions(result);
 

--- a/src/events/ParsingEvents.js
+++ b/src/events/ParsingEvents.js
@@ -12,7 +12,7 @@ const defaultTransactionFieldToColumn = {
 }
 
 
-const parseCSV = (file, rowToObject) => {
+const parseCSV = (file, rowToObject, fieldToCol=defaultTransactionFieldToColumn) => {
 
     return new Promise((resolve, reject) => {
 


### PR DESCRIPTION
    Pass the transaction field to column mapping to parseCSV and use it to
    customize how an uploaded CSV is parsed.