### PR TITLE
PB-33: Create Component to Upload Saved State

### DIFF
--- a/src/components/FileUpload/FileInput.js
+++ b/src/components/FileUpload/FileInput.js
@@ -1,15 +1,26 @@
-import React from 'react';
-import { Form } from 'react-bootstrap';
-import { parseCSVColumns } from '../../events/ParsingEvents';
 import { useContext } from 'react';
+import { Form } from 'react-bootstrap';
 import { TransactionParsingContext, ACTION_SET_COLUMNS } from '../../contexts/TransactionParsingContext';
+import { parseCSVColumns } from '../../events/ParsingEvents';
 
 
 const FileInput = ({ onChange }) => {
 
+    return (
+        <Form>
+            <Form.Group>
+                <Form.Label for='fileInput'>Choose a file:</Form.Label>
+                <Form.Control type="file" onChange={onChange} id='fileInput' />
+            </Form.Group>
+        </Form>
+    );
+}
+
+
+const NewFileInput = ({ onChange }) => {
     const { dispatch } = useContext(TransactionParsingContext);
 
-    const handleOnChange = (event) => {
+    const handleOnNewFileChange = (event) => {
         onChange(event);
         parseCSVColumns(event.target.files[0]).then(result => {
 
@@ -21,18 +32,12 @@ const FileInput = ({ onChange }) => {
             });
 
         });
-
     }
 
     return (
-        <Form>
-            <Form.Group>
-                <Form.Label for='fileInput'>Choose a file:</Form.Label>
-                <Form.Control type="file" onChange={handleOnChange} id='fileInput' />
-            </Form.Group>
-        </Form>
-    );
+        <FileInput onChange={handleOnNewFileChange} />
+    )
 }
 
 
-export default FileInput;
+export { FileInput, NewFileInput };

--- a/src/components/FileUpload/FileUploadParser.js
+++ b/src/components/FileUpload/FileUploadParser.js
@@ -1,6 +1,6 @@
 import { useState, useContext } from "react";
 import { Button } from "react-bootstrap";
-import FileInput from "./FileInput";
+import { NewFileInput } from "./FileInput";
 import ColumnParser from "./ColumnParser";
 import { DataContext, ACTION_SET_TRANSACTIONS } from "../../contexts/DataContext";
 import { TransactionParsingProvider, TransactionParsingContext } from "../../contexts/TransactionParsingContext";
@@ -50,7 +50,7 @@ const FileUploadParser = () => {
     return (
         <TransactionParsingProvider>
             <h1>File Upload Parser</h1>
-            <FileInput onChange={setFile} />
+            <NewFileInput onChange={setFile} />
             <ColumnParser />
             <ParseButton file={file} />
         </TransactionParsingProvider>

--- a/src/components/FileUpload/StateUploadParser.js
+++ b/src/components/FileUpload/StateUploadParser.js
@@ -1,0 +1,35 @@
+import { useState, useContext } from 'react';
+import { Button } from 'react-bootstrap';
+import { FileInput } from './FileInput';
+import { DataContext, ACTION_SET_STATE } from '../../contexts/DataContext';
+import { parseStateFile } from '../../events/ParsingEvents';
+
+
+const StateUploadParser = () => {
+
+    const [file, setFile] = useState(null);
+    const { dispatch } = useContext(DataContext);
+
+    const handleOnParseClick = (event) => {
+
+        parseStateFile(file.target.files[0]).then(result => {
+
+            dispatch({
+                type: ACTION_SET_STATE,
+                payload: result,
+            });
+    
+        });
+    }
+
+    return (
+        <div>
+            <h1>StateUploadParser</h1>
+            <FileInput onChange={setFile} />
+            <Button variant="primary" onClick={handleOnParseClick}>Parse</Button>
+        </div>
+    )
+}
+
+
+export { StateUploadParser };

--- a/src/components/FileUpload/UploadTab.js
+++ b/src/components/FileUpload/UploadTab.js
@@ -1,0 +1,41 @@
+import { Button, Card, Collapse, Tab, Tabs } from 'react-bootstrap';
+import { faUpload } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { StateUploadParser } from './StateUploadParser';
+
+
+const UploadTab = ({ isOpen }) => {
+
+    return (
+        <div className={`sidebar ${isOpen ? 'open' : 'collapsed'}`}>
+            <Collapse in={isOpen} dimension="width">
+                <Card class='sidebar-content'>
+                    <Tabs defaultActiveKey="existing" class="sidebar-collapse">
+                        <Tab eventKey="existing" title="Existing">
+                            <StateUploadParser/>
+                        </Tab>
+                        <Tab eventKey="new" title="New">
+                        </Tab>
+                    </Tabs>
+                </Card>
+            </Collapse>
+        </div>
+    )
+
+}
+
+
+const UploadTabButton = ({ isOpen, onClick }) => {
+    return (
+        <Button variant="primary"
+            onClick={onClick}
+            aria-controls="sidebar-collapse"
+            aria-expanded={isOpen}
+            className='circular-button'>
+            <FontAwesomeIcon icon={faUpload} />
+        </Button>
+    )
+}
+
+
+export { UploadTabButton, UploadTab };

--- a/src/components/SideBar/Main.js
+++ b/src/components/SideBar/Main.js
@@ -6,27 +6,31 @@ import TagView from "./TagView";
 import TransactionView from "./TransactionView";
 import TransactionDescriptionView from "./TransactionDescriptionView";
 import DownloadButton from "../DownloadButton";
+import { UploadTabButton, UploadTab } from "../FileUpload/UploadTab";
 import { SideBarProvider } from "../../contexts/SideBarContext";
 
 
 const SideBar = () => {
     const [open, setOpen] = useState(false);
+    const [uploadOpen, setUploadOpen] = useState(false);
 
     return (
         <SideBarProvider>
 
             <div className={`sidebar ${open ? 'open' : 'collapsed'} override-bs layout-overlay layout-top-right`}>
-            <div class="icon-bar">
-                <Button
-                    onClick={() => setOpen(!open)}
-                    aria-controls="sidebar-collapse"
-                    aria-expanded={open}
-                    className='circular-button sidebar-button'
-                >
-                    <FontAwesomeIcon icon={faBars} />
-                </Button>
-                <DownloadButton />
+                <div class="icon-bar">
+                    <UploadTabButton isOpen={uploadOpen} onClick={() => {setOpen(false);setUploadOpen(!uploadOpen)}} />
+                    <Button
+                        onClick={() => {setOpen(!open); setUploadOpen(false)}}
+                        aria-controls="sidebar-collapse"
+                        aria-expanded={open}
+                        className='circular-button sidebar-button'
+                    >
+                        <FontAwesomeIcon icon={faBars} />
+                    </Button>
+                    <DownloadButton />
                 </div>
+                <UploadTab isOpen={uploadOpen}/>
                 <Collapse in={open} dimension="width">
                     <Card class='sidebar-content'>
                         <Tabs defaultActiveKey="transactions" class="sidebar-collapse">

--- a/src/contexts/DataContext.js
+++ b/src/contexts/DataContext.js
@@ -10,6 +10,7 @@ export const ACTION_DELETE_TAG = 'DELETE_TAG';
 export const ACTION_ADD_TAG = 'ADD_TAG';
 export const ACTION_SET_TRANSACTION_DESCRIPTION_TAG = 'SET_TRANSACTION_DESCRIPTION_TAG';
 export const ACTION_TOGGLE_OBJECT_VISIBILITY = 'TOGGLE_TRANSACTION_VISIBILITY';
+export const ACTION_SET_STATE = 'SET_STATE';
 
 export const DEFAULT_TAG_ID = 1;
 
@@ -82,6 +83,9 @@ const DataReducer = (state, action) => {
                 descriptions: state.descriptions,
                 tags: state.tags
             }
+
+        case ACTION_SET_STATE:
+            return action.payload;
 
             
         default:

--- a/src/models/Tag.js
+++ b/src/models/Tag.js
@@ -1,9 +1,9 @@
 class Tag {
-    constructor(id, name, colour) {
+    constructor(id, name, colour, isActive=true) {
         this.id = id;
         this.name = name;
         this.colour = colour;
-        this.isActive = true;
+        this.isActive = isActive;
     }
 }
 

--- a/src/models/Transaction.js
+++ b/src/models/Transaction.js
@@ -1,12 +1,12 @@
 class Transaction {
-    constructor(id, description, amount, date, transactionType){
+
+    constructor(id, description, amount, date, transactionType, isActive=true){
         this.id = id;
         this.description = description;
         this.amount = amount;
         this.date = date;
         this.transactionType = transactionType;
-        this.tag = null;
-        this.isActive = true;
+        this.isActive = isActive;
     };
 
     setTag(tag){

--- a/src/models/TransactionDescription.js
+++ b/src/models/TransactionDescription.js
@@ -1,8 +1,9 @@
 class TransactionDescription {
-    constructor(id, description){
+    constructor(id, description, tag=null, isActive=true){
         this.id = id;
         this.name = description;
-        this.isActive = true;
+        this.tag = tag;
+        this.isActive = isActive;
     }
 
     isVisible() {


### PR DESCRIPTION
    Create component for users to upload saved state file downloaded from the
    state download component.

    To organize the components in the app, a new upload tab is available in
    parallel to the current side bar which only held tabs pertaining to
    transactions. The new upload tab will eventually house the existing file
    upload component.