### PR TITLE
PB-39: Disable React Strict Mode

### DIFF
--- a/src/components/SideBar/TransactionDescriptionView.js
+++ b/src/components/SideBar/TransactionDescriptionView.js
@@ -46,7 +46,7 @@ const TransactionDescriptionRow = ({ transactionDescription }) => {
                     </Dropdown.Toggle>
                     <Dropdown.Menu>
                         {state.tags.map((tag) => {
-                            return <Dropdown.Item onClick={() => handleSelection(tag)}>{tag.name}</Dropdown.Item>
+                            return <Dropdown.Item key={tag.id} onClick={() => handleSelection(tag)}>{tag.name}</Dropdown.Item>
                         })}
                     </Dropdown.Menu>
                 </Dropdown>
@@ -75,7 +75,7 @@ const TransactionDescriptionTable = () => {
             </thead>
             <tbody>
                 {transactionDescriptions.map((transactionDescription) => {
-                    return <TransactionDescriptionRow transactionDescription={transactionDescription} />
+                    return <TransactionDescriptionRow key={transactionDescription.id} transactionDescription={transactionDescription} />
                 })}
             </tbody>
         </Table>

--- a/src/components/SideBar/TransactionView.js
+++ b/src/components/SideBar/TransactionView.js
@@ -104,7 +104,7 @@ const TransactionTable = () => {
             </thead>
             <tbody>
                 {transactions.map((transaction) => {
-                    return <TransactionRow transaction={transaction} />
+                    return <TransactionRow key={transaction.id} transaction={transaction} />
                 })}
             </tbody>
         </Table>

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,9 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
+//  <React.StrictMode>
     <App />
-  </React.StrictMode>
+//  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
    Disable React's strict mode, which enforces that reducers are pure
    functions. This is not the case for this app's reducers, which handle state
    changes.