### PR TITLE
PB-42: Enable Description Table Filtering

### DIFF
--- a/src/components/FileUpload/FileUploadParser.js
+++ b/src/components/FileUpload/FileUploadParser.js
@@ -2,9 +2,9 @@ import { useState, useContext } from "react";
 import { Button, Modal } from "react-bootstrap";
 import { NewFileInput } from "./FileInput";
 import ColumnParser from "./ColumnParser";
-import { DataContext, ACTION_SET_TRANSACTIONS, ACTION_ADD_TRANSACTIONS } from "../../contexts/DataContext";
+import { DataContext, ACTION_SET_TRANSACTIONS, ACTION_ADD_TRANSACTIONS, DEFAULT_TAG_ID } from "../../contexts/DataContext";
 import { TransactionParsingProvider, TransactionParsingContext } from "../../contexts/TransactionParsingContext";
-import { normalizeTransactions, parseCSV, rowToTransaction } from "../../events/ParsingEvents";
+import { normalizeTransactions, parseCSV, rowToTransaction, setDefaultTag } from "../../events/ParsingEvents";
 
 
 const ConfirmationModal = ({ show, onHide, onConfirm, modalHeader, modalMessage, modalTheme, confirmLabel }) => {
@@ -31,7 +31,7 @@ const ConfirmationModal = ({ show, onHide, onConfirm, modalHeader, modalMessage,
 
 const ParseButton = ({ children, file, eventType, variant, confirmHeader, confirmMessage, confirmLabel }) => {
 
-    const { dispatch } = useContext(DataContext);
+    const { state: dataState, dispatch } = useContext(DataContext);
     const { state } = useContext(TransactionParsingContext);
     const { dateCol, descriptionCol, expenseCol, depositCol } = state;
 
@@ -54,6 +54,8 @@ const ParseButton = ({ children, file, eventType, variant, confirmHeader, confir
         Promise.all(parsingPromises).then(results => {
             const transactions = results.flat();
             const transactionDescriptions = normalizeTransactions(transactions);
+            const defaultTag = dataState.tags.find((tag) => tag.id == DEFAULT_TAG_ID);
+            setDefaultTag(transactionDescriptions, defaultTag);
 
             const fileDetails = {
                 transactions: transactions,

--- a/src/components/SideBar/TransactionDescriptionView.js
+++ b/src/components/SideBar/TransactionDescriptionView.js
@@ -1,9 +1,11 @@
-import { Table, Dropdown } from 'react-bootstrap';
 import { useContext } from 'react';
-import { ACTION_SET_TRANSACTION_DESCRIPTION_TAG, DataContext, DEFAULT_TAG_ID, ACTION_TOGGLE_OBJECT_VISIBILITY } from '../../contexts/DataContext';
+import { Table, Button, Dropdown } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlay, faPause } from '@fortawesome/free-solid-svg-icons';
-import { Button } from 'react-bootstrap';
+import { FilterForm } from './Utils';
+import { ACTION_SET_TRANSACTION_DESCRIPTION_TAG, DataContext, ACTION_TOGGLE_OBJECT_VISIBILITY } from '../../contexts/DataContext';
+import { SideBarContext, ACTION_SET_DESCRIPTION_NAME, ACTION_SET_DESCRIPTION_TAG } from '../../contexts/SideBarContext';
+import { filterTransactionDescriptions } from '../../events/SideBarEvents';
 
 
 const TransactionDescriptionRow = ({ transactionDescription }) => {
@@ -17,11 +19,6 @@ const TransactionDescriptionRow = ({ transactionDescription }) => {
                 isActive: !transactionDescription.isActive
             }
         });
-    }
-
-    if (transactionDescription.tag == null) {
-        const defaultTag = state.tags.find((tag) => tag.id == DEFAULT_TAG_ID);
-        transactionDescription.tag = defaultTag;
     }
 
     const handleSelection = (tag) => {
@@ -60,11 +57,14 @@ const TransactionDescriptionRow = ({ transactionDescription }) => {
 const TransactionDescriptionTable = () => {
 
     const { state } = useContext(DataContext);
-    const transactionDescriptions = state.descriptions;
+    const { state: sideBarState } = useContext(SideBarContext);
+    const { descriptionName, descriptionTag } = sideBarState;
 
+    let transactionDescriptions = state.descriptions;
+    transactionDescriptions = filterTransactionDescriptions(transactionDescriptions, descriptionName, descriptionTag);
 
     return (
-        <Table>
+        <Table striped bordered hover>
             <thead>
                 <tr>
                     <th>Name</th>
@@ -84,9 +84,25 @@ const TransactionDescriptionTable = () => {
 
 
 const TransactionDescriptionView = () => {
+
+    const { dispatch } = useContext(SideBarContext);
+
+    const filterFieldNames = ['Name', 'Tag'];
+    const dispatchTypes = {
+        'Name': [ACTION_SET_DESCRIPTION_NAME],
+        'Tag': [ACTION_SET_DESCRIPTION_TAG],
+    }
+    const dateFields = [];
+    const floatFields = [];
+
     return (
         <div>
             <h1>Transaction Descriptions</h1>
+            <FilterForm dispatch={dispatch}
+                fieldNames={filterFieldNames}
+                dispatchTypes={dispatchTypes}
+                dateFields={dateFields}
+                floatFields={floatFields} />
             <TransactionDescriptionTable />
         </div>
     )

--- a/src/components/SideBar/TransactionView.js
+++ b/src/components/SideBar/TransactionView.js
@@ -1,7 +1,8 @@
 import { useContext } from "react";
 import { Table, Form, Button } from "react-bootstrap";
+import { FilterForm } from "./Utils";
 import { ACTION_TOGGLE_OBJECT_VISIBILITY, DataContext } from "../../contexts/DataContext";
-import { SideBarContext } from "../../contexts/SideBarContext";
+import { SideBarContext, ACTION_SET_MIN_DATE, ACTION_SET_MAX_DATE, ACTION_SET_DESCRIPTION, ACTION_SET_MIN_AMOUNT, ACTION_SET_MAX_AMOUNT, ACTION_SET_TAG } from "../../contexts/SideBarContext";
 import { filterTransactions } from "../../events/SideBarEvents";
 import { FormatMoney, FormatDate } from "../../utils/Utils";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -27,56 +28,9 @@ const TransactionRow = ({ transaction }) => {
             <td>{transaction.description.name}</td>
             <td>{FormatMoney(transaction.amount)}</td>
             <td>{transaction.transactionType}</td>
+            <td>{transaction.description.tag.name}</td>
             <td><Button><FontAwesomeIcon onClick={handleActiveButtonClick} icon={transaction.isActive ? faPlay : faPause} /></Button></td>
         </tr>
-    );
-}
-
-const FilterTransactionsForm = () => {
-
-    const { dispatch } = useContext(SideBarContext);
-
-    const handleOnDataChange = (event) => {
-
-        const dispatchType = event.target.getAttribute('dispatchType');
-        let value = event.target.value;
-
-        if (['SET_MIN_DATE', 'SET_MAX_DATE'].includes(dispatchType)) {
-            value = value != '' ? new Date(value) : value;
-        } else if (['SET_MIN_AMOUNT', 'SET_MAX_AMOUNT'].includes(dispatchType)) {
-            value = value != '' ? parseFloat(value) : value;
-        }
-
-        dispatch({
-            type: dispatchType,
-            payload: {
-                data: value,
-            }
-        });
-
-    }
-
-    return (
-        <Form>
-            <Table>
-                <tbody>
-                    <tr>
-                        <td>Date</td>
-                        <td>From: <Form.Control type="date" dispatchtype="SET_MIN_DATE" onChange={handleOnDataChange} /></td>
-                        <td>To: <Form.Control type="date" dispatchtype="SET_MAX_DATE" onChange={handleOnDataChange} /></td>
-                    </tr>
-                    <tr>
-                        <td>Description</td>
-                        <td colSpan="2"><Form.Control type="text" dispatchtype="SET_DESCRIPTION" onChange={handleOnDataChange} placeholder="Search" /></td>
-                    </tr>
-                    <tr>
-                        <td>Amount</td>
-                        <td>Min: <Form.Control type="number" dispatchtype="SET_MIN_AMOUNT" onChange={handleOnDataChange} /></td>
-                        <td>Max: <Form.Control type="number" dispatchtype="SET_MAX_AMOUNT" onChange={handleOnDataChange} /></td>
-                    </tr>
-                </tbody>
-            </Table>
-        </Form>
     );
 }
 
@@ -84,12 +38,12 @@ const FilterTransactionsForm = () => {
 const TransactionTable = () => {
 
     const { state: sideBarState } = useContext(SideBarContext);
-    const { minDate, maxDate, description, minAmount, maxAmount } = sideBarState;
+    const { minDate, maxDate, description, minAmount, maxAmount, tag } = sideBarState;
 
     const { state: dataState } = useContext(DataContext);
 
     let transactions = 'transactions' in dataState ? dataState.transactions : [];
-    transactions = filterTransactions(transactions, minDate, maxDate, description, minAmount, maxAmount);
+    transactions = filterTransactions(transactions, minDate, maxDate, description, minAmount, maxAmount, tag);
 
     return (
         <Table striped bordered hover>
@@ -99,6 +53,7 @@ const TransactionTable = () => {
                     <th>Description</th>
                     <th>Amount</th>
                     <th>Transaction Type</th>
+                    <th>Tag</th>
                     <th></th>
                 </tr>
             </thead>
@@ -113,10 +68,28 @@ const TransactionTable = () => {
 
 
 const TransactionView = () => {
+
+    const { dispatch } = useContext(SideBarContext);
+
+    const filterFieldNames = ['Date', 'Description', 'Amount', 'Tag'];
+    const dispatchTypes = {
+        'Date': [ACTION_SET_MIN_DATE, ACTION_SET_MAX_DATE],
+        'Description': [ACTION_SET_DESCRIPTION],
+        'Amount': [ACTION_SET_MIN_AMOUNT, ACTION_SET_MAX_AMOUNT],
+        'Tag': [ACTION_SET_TAG],
+    }
+    const dateFields = ['Date'];
+    const floatFields = ['Amount'];
+
+
     return (
         <div>
             <h1>Transactions</h1>
-            <FilterTransactionsForm />
+            <FilterForm dispatch={dispatch}
+                fieldNames={filterFieldNames}
+                dispatchTypes={dispatchTypes}
+                dateFields={dateFields}
+                floatFields={floatFields} />
             <TransactionTable />
         </div>
     );

--- a/src/components/SideBar/Utils.js
+++ b/src/components/SideBar/Utils.js
@@ -1,0 +1,128 @@
+import { Button, Form, Table } from 'react-bootstrap';
+import { ACTION_CLEAR_FILTERS } from '../../contexts/SideBarContext';
+import { useRef } from 'react';
+
+
+const FilterDateInput = ({ fieldName, dispatchTypes, onChange }) => {
+    return (
+        <tr>
+            <td>{fieldName}</td>
+            <td>From: <Form.Control type="date" dispatchtype={dispatchTypes[0]} onChange={onChange} /></td>
+            <td>To: <Form.Control type="date" dispatchtype={dispatchTypes[1]} onChange={onChange} /></td>
+        </tr>
+    );
+};
+
+
+const FilterNumberInput = ({ fieldName, dispatchTypes, onChange }) => {
+    return (
+        <tr>
+            <td>{fieldName}</td>
+            <td>Min: <Form.Control type="number" dispatchtype={dispatchTypes[0]} onChange={onChange} /></td>
+            <td>Max: <Form.Control type="number" dispatchtype={dispatchTypes[1]} onChange={onChange} /></td>
+        </tr>
+    );
+};
+
+
+const FilterTextInput = ({ fieldName, dispatchType, onChange }) => {
+    return (
+        <tr>
+            <td>{fieldName}</td>
+            <td colSpan="2"><Form.Control type="text" dispatchtype={dispatchType} onChange={onChange} placeholder="Search" /></td>
+        </tr>
+    );
+};
+
+
+
+
+
+/**
+ * 
+ * @param {*} dispatch - Dispatch function to send events to
+ * @param {*} fieldNames - Array of field names to filter by
+ * @param {*} dispatchTypes - Object where properties are fields and values are dispatch types for each field.
+ * @param {*} dateFields - Array of fields that are dates. Subset of fieldNames
+ * @param {*} floatFields - Array of fields that are floats. Subset of fieldNames
+ */
+const FilterForm = ({ dispatch, fieldNames, dispatchTypes, dateFields, floatFields }) => {
+
+    const filterForm = useRef(null);
+
+    const handleOnDataChange = (event) => {
+
+        const dispatchType = event.target.getAttribute('dispatchType');
+        let value = event.target.value;
+
+        let dateDispatchTypes = [];
+        dateFields.forEach(field => {
+            dispatchTypes[field].forEach(dispatchType => {
+                dateDispatchTypes.push(dispatchType);
+            });
+        });
+
+        let floatDispatchTypes = [];
+        floatFields.forEach(field => {
+            dispatchTypes[field].forEach(dispatchType => {
+                floatDispatchTypes.push(dispatchType);
+            });
+        });
+
+        if (dateDispatchTypes.includes(dispatchType)) {
+            value = value != '' ? new Date(value) : value;
+
+        } else if (floatDispatchTypes.includes(dispatchType)) {
+            value = value != '' ? parseFloat(value) : value;
+        }
+
+        dispatch({
+            type: dispatchType,
+            payload: {
+                data: value,
+            }
+        });
+
+    };
+
+    const handleOnClearClick = (event) => {
+
+        const allDispatchTypes = [];
+        Object.values(dispatchTypes).forEach(dispatchTypeList => {
+            dispatchTypeList.forEach(dispatchType => {
+                allDispatchTypes.push(dispatchType);
+            });
+        });
+
+        dispatch({
+            type: ACTION_CLEAR_FILTERS,
+            payload: {
+                dispatchTypes: allDispatchTypes,
+            }
+        });
+
+        filterForm.current.reset();
+
+    }
+
+    return (
+        <Form ref={filterForm}>
+            <Table>
+                <tbody>
+                    {fieldNames.map((fieldName) => { 
+                        if (dateFields.includes(fieldName)) {
+                            return <FilterDateInput key={fieldName} fieldName={fieldName} dispatchTypes={dispatchTypes[fieldName]} onChange={handleOnDataChange} />
+                        } else if (floatFields.includes(fieldName)) {
+                            return <FilterNumberInput key={fieldName} fieldName={fieldName} dispatchTypes={dispatchTypes[fieldName]} onChange={handleOnDataChange} />
+                        } else {
+                            return <FilterTextInput key={fieldName} fieldName={fieldName} dispatchType={dispatchTypes[fieldName]} onChange={handleOnDataChange} />
+                        }
+                    })}
+                </tbody>
+            </Table>
+            <Button variant="warning" onClick={handleOnClearClick} className="layout-right-aligned">Clear</Button>
+        </Form>
+    );
+}
+
+export { FilterForm };

--- a/src/contexts/SideBarContext.js
+++ b/src/contexts/SideBarContext.js
@@ -1,27 +1,54 @@
 import React, { useReducer } from 'react';
 
 
+export const ACTION_SET_MIN_DATE = 'SET_MIN_DATE';
+export const ACTION_SET_MAX_DATE = 'SET_MAX_DATE';
+export const ACTION_SET_DESCRIPTION = 'SET_DESCRIPTION';
+export const ACTION_SET_MIN_AMOUNT = 'SET_MIN_AMOUNT';
+export const ACTION_SET_MAX_AMOUNT = 'SET_MAX_AMOUNT';
+export const ACTION_SET_TAG = 'SET_TAG';
+export const ACTION_SET_DESCRIPTION_NAME = 'SET_DESCRIPTION_NAME';
+export const ACTION_SET_DESCRIPTION_TAG = 'SET_DESCRIPTION_TAG';
+export const ACTION_CLEAR_FILTERS = 'CLEAR_FILTERS';
+
+
 const actionToField = {
     'SET_MIN_DATE': 'minDate',
     'SET_MAX_DATE': 'maxDate',
     'SET_DESCRIPTION': 'description',
     'SET_MIN_AMOUNT': 'minAmount',
     'SET_MAX_AMOUNT': 'maxAmount',
+    'SET_TAG': 'tag',
+    'SET_DESCRIPTION_NAME': 'descriptionName',
+    'SET_DESCRIPTION_TAG': 'descriptionTag',
 }
 
 
 const SideBarReducer = (state, action) => {
 
-    if (!(action.type in actionToField)) {
-        return state;
+
+
+    if (action.type in actionToField) {
+        const field = actionToField[action.type];
+
+        return {
+            ...state,
+            [field]: action.payload.data
+        }
     }
 
-    const field = actionToField[action.type];
+    switch(action.type) {
+        case ACTION_CLEAR_FILTERS:
+            const { dispatchTypes } = action.payload;
 
-    return {
-        ...state,
-        [field]: action.payload.data
+            const newState = {};
+            Object.keys(state).forEach(field => {
+                newState[field] = '';
+            });
+
+            return newState;
     }
+
 
 }
 
@@ -33,6 +60,9 @@ const initialState = {
     description: '',
     minAmount: '',
     maxAmount: '',
+    tag: '',
+    descriptionName: '',
+    descriptionTag: '',
 }
 
 const SideBarProvider = ({ children }) => {

--- a/src/events/ParsingEvents.js
+++ b/src/events/ParsingEvents.js
@@ -91,6 +91,12 @@ const normalizeTransactions = (transactions) => {
 
 }
 
+const setDefaultTag = (transactionDescriptions, defaultTag) => {    
+        transactionDescriptions.forEach(transactionDescription => {
+            transactionDescription.tag = defaultTag;
+        });
+}
+
 
 const rowToTransaction = (row, transactionFieldToColumn = defaultTransactionFieldToColumn) => {
 
@@ -167,4 +173,4 @@ const parseStateFile = (file) => {
 }
 
 
-export { parseCSV, rowToTransaction, normalizeTransactions, parseCSVColumns, parseStateFile };
+export { parseCSV, rowToTransaction, normalizeTransactions, setDefaultTag, parseCSVColumns, parseStateFile };

--- a/src/events/SideBarEvents.js
+++ b/src/events/SideBarEvents.js
@@ -1,4 +1,4 @@
-const filterTransactions = (transactions, minDate, maxDate, description, minAmount, maxAmount) => {
+const filterTransactions = (transactions, minDate, maxDate, description, minAmount, maxAmount, tag) => {
 
     if (minDate !== '') {
         transactions = transactions.filter(transaction => {
@@ -8,7 +8,7 @@ const filterTransactions = (transactions, minDate, maxDate, description, minAmou
         transactions = transactions.filter(transaction => transaction.date <= maxDate);
     }
     if (description !== '') {
-        transactions = transactions.filter(transaction => transaction.description.includes(description));
+        transactions = transactions.filter(transaction => transaction.description.name.includes(description));
     }
     if (minAmount !== '') {
         transactions = transactions.filter(transaction => transaction.amount >= minAmount);
@@ -16,7 +16,25 @@ const filterTransactions = (transactions, minDate, maxDate, description, minAmou
     if (maxAmount !== '') {
         transactions = transactions.filter(transaction => transaction.amount <= maxAmount);
     }
+    if (tag !== '') {
+        transactions = transactions.filter(transaction => transaction.description.tag.name.includes(tag));
+    }
     return transactions;
 }
 
-export { filterTransactions };
+
+const filterTransactionDescriptions = (transactionDescriptions, name, tag) => {
+    console.log(name);
+
+    if (name !== '') {
+        transactionDescriptions = transactionDescriptions.filter(transactionDescription => transactionDescription.name.includes(name));
+    }
+    if (tag !== '') {
+        transactionDescriptions = transactionDescriptions.filter(transactionDescription => transactionDescription.tag.name.includes(tag));
+    }
+    return transactionDescriptions;
+
+}
+
+
+export { filterTransactions, filterTransactionDescriptions };


### PR DESCRIPTION
    Enable users to filter transaction descriptions by name or tag. Leverage
    the existing filter form component for the transaction table and refactor
    the form to be reusable for the description table.

    Add tag as a searchable field for the transaction table.