### PR TITLE
PB-46: Display Transaction Summary in Table Form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import './App.css';
 import './css/layouts.css';
 import './css/modules.css';
 import TransactionChart from './components/Chart/TransactionChart';
+import TransactionTable from './components/Chart/TransactionTable';
 import SideBar from './components/SideBar/Main';
 import { DataProvider } from './contexts/DataContext';
 
@@ -10,6 +11,7 @@ function App() {
     <div>
       <DataProvider>
         <TransactionChart />
+        <TransactionTable />
         <SideBar />
       </DataProvider>
     </div>

--- a/src/components/Chart/TransactionTable.js
+++ b/src/components/Chart/TransactionTable.js
@@ -1,0 +1,48 @@
+import { useContext } from 'react';
+import { Table } from 'react-bootstrap';
+import { fetchChartData } from '../../utils/ChartUtils';
+import { DataContext } from '../../contexts/DataContext';
+import { DateInterval } from '../../utils/Enums';
+import { FormatMoney } from '../../utils/Utils';
+
+const TransactionTable = () => {
+
+    const { state } = useContext(DataContext);
+    const { transactions } = state;
+    const data = fetchChartData(transactions, DateInterval.MONTH);
+
+    const fields = ['Total'];
+    const summaries = {};
+    fields.forEach(field => {
+        const sum = data.reduce((acc, item) => acc + item[field], 0);
+        summaries[field] = {
+            'Average': sum/data.length, 
+            'Total': sum
+        }
+    });
+
+    return (
+        <Table>
+            <thead>
+                <tr>
+                    <th></th>
+                    <th>Average</th>
+                    {data.map((item, index) => <th>{item.key}</th>)}
+                    <th>Total</th>
+                </tr>
+            </thead>
+            <tbody>
+                {fields.map(field => (
+                    <tr>
+                        <td>{field}</td>
+                        <td>{FormatMoney(summaries[field]['Average'])}</td>
+                        {data.map((item, index) => <td>{FormatMoney(item[field])}</td>)}
+                        <td>{FormatMoney(summaries[field]['Total'])}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    )
+}
+
+export default TransactionTable;

--- a/src/utils/ChartUtils.js
+++ b/src/utils/ChartUtils.js
@@ -98,4 +98,5 @@ function fetchChartData(transactions, dateInterval = DateInterval.DAY, chartCate
     return Object.values(data);
 }
 
+
 export { fetchChartData };


### PR DESCRIPTION
    Display the data shown in the summary chart in table form. Currently, the
    table is locked to show only on a monthly basis due to the increased size
    from displaying in daily form.