### PR TITLE
PB-49: Close Upload Tab on Upload

### DIFF
--- a/src/components/FileUpload/FileUploadParser.js
+++ b/src/components/FileUpload/FileUploadParser.js
@@ -29,7 +29,7 @@ const ConfirmationModal = ({ show, onHide, onConfirm, modalHeader, modalMessage,
 }
 
 
-const ParseButton = ({ children, file, eventType, variant, confirmHeader, confirmMessage, confirmLabel }) => {
+const ParseButton = ({ children, file, eventType, variant, confirmHeader, confirmMessage, confirmLabel, onClick }) => {
 
     const { state: dataState, dispatch } = useContext(DataContext);
     const { state } = useContext(TransactionParsingContext);
@@ -67,6 +67,7 @@ const ParseButton = ({ children, file, eventType, variant, confirmHeader, confir
                 payload: fileDetails,
             });
         });
+        onClick();
     }
 
     return (<>
@@ -84,7 +85,7 @@ const ParseButton = ({ children, file, eventType, variant, confirmHeader, confir
 }
 
 
-const FileUploadParser = () => {
+const FileUploadParser = ({ onUpload }) => {
 
     const [file, setFile] = useState('');
 
@@ -98,12 +99,14 @@ const FileUploadParser = () => {
                 confirmHeader="Starting New Chart"
                 confirmMessage="Are you sure you want start over with new data?"
                 confirmLabel="Start Over"
+                onClick={onUpload}
                 variant="warning">New</ParseButton>
             <ParseButton file={file}
                 eventType={ACTION_ADD_TRANSACTIONS}
                 confirmHeader="Adding Transactions"
                 confirmMessage="Are you sure you want to add new data?"
                 confirmLabel="Add"
+                onClick={onUpload}
                 variant="primary">Add</ParseButton>
         </TransactionParsingProvider>
     )

--- a/src/components/FileUpload/StateUploadParser.js
+++ b/src/components/FileUpload/StateUploadParser.js
@@ -5,7 +5,7 @@ import { DataContext, ACTION_SET_STATE } from '../../contexts/DataContext';
 import { parseStateFile } from '../../events/ParsingEvents';
 
 
-const StateUploadParser = () => {
+const StateUploadParser = ({ onUpload }) => {
 
     const [file, setFile] = useState(null);
     const { dispatch } = useContext(DataContext);
@@ -18,8 +18,9 @@ const StateUploadParser = () => {
                 type: ACTION_SET_STATE,
                 payload: result,
             });
-    
+
         });
+        onUpload();
     }
 
     return (

--- a/src/components/FileUpload/UploadTab.js
+++ b/src/components/FileUpload/UploadTab.js
@@ -5,7 +5,7 @@ import { StateUploadParser } from './StateUploadParser';
 import FileUploadParser from './FileUploadParser';
 
 
-const UploadTab = ({ isOpen }) => {
+const UploadTab = ({ isOpen, onUpload }) => {
 
     return (
         <div className={`sidebar ${isOpen ? 'open' : 'collapsed'}`}>
@@ -13,10 +13,10 @@ const UploadTab = ({ isOpen }) => {
                 <Card className='sidebar-content'>
                     <Tabs defaultActiveKey="existing" className="sidebar-collapse">
                         <Tab eventKey="existing" title="Existing">
-                            <StateUploadParser/>
+                            <StateUploadParser onUpload={onUpload} />
                         </Tab>
                         <Tab eventKey="new" title="New">
-                            <FileUploadParser/>
+                            <FileUploadParser onUpload={onUpload}/>
                         </Tab>
                     </Tabs>
                 </Card>

--- a/src/components/SideBar/Main.js
+++ b/src/components/SideBar/Main.js
@@ -11,27 +11,27 @@ import { SideBarProvider } from "../../contexts/SideBarContext";
 
 
 const SideBar = () => {
-    const [open, setOpen] = useState(false);
     const [uploadOpen, setUploadOpen] = useState(false);
+    const [dataOpen, setDataOpen] = useState(false);
 
     return (
         <SideBarProvider>
 
-            <div className={`sidebar ${open ? 'open' : 'collapsed'} override-bs layout-overlay layout-top-right`}>
+            <div className={`sidebar ${dataOpen ? 'open' : 'collapsed'} override-bs layout-overlay layout-top-right`}>
                 <div className="icon-bar">
-                    <UploadTabButton isOpen={uploadOpen} onClick={() => {setOpen(false);setUploadOpen(!uploadOpen)}} />
+                    <UploadTabButton isOpen={uploadOpen} onClick={() => {setDataOpen(false);setUploadOpen(!uploadOpen)}} />
                     <Button
-                        onClick={() => {setOpen(!open); setUploadOpen(false)}}
+                        onClick={() => {setDataOpen(!dataOpen); setUploadOpen(false)}}
                         aria-controls="sidebar-collapse"
-                        aria-expanded={open}
+                        aria-expanded={dataOpen}
                         className='circular-button sidebar-button'
                     >
                         <FontAwesomeIcon icon={faBars} />
                     </Button>
                     <DownloadButton />
                 </div>
-                <UploadTab isOpen={uploadOpen}/>
-                <Collapse in={open} dimension="width">
+                <UploadTab isOpen={uploadOpen} onUpload={() => {setDataOpen(false);setUploadOpen(false);}}/>
+                <Collapse in={dataOpen} dimension="width">
                     <Card className='sidebar-content'>
                         <Tabs defaultActiveKey="transactions" className="sidebar-collapse">
                             <Tab eventKey="transactions" title="Transactions">


### PR DESCRIPTION
    Close the upload tab when the user completes a file upload. This opens up
    the page to reveal the chart and table generated from the new uploaded
    data.